### PR TITLE
fix: use ICMP ECHO instead of UDP for linux/macos traceroute

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 If you're having trouble connecting to your Vercel deployment, you might be asked by our support engineers to run these debug commands.
 
-Run the below mentioned command, depending on your operating system, from a terminal of your choice. This will roughly take about 5 minutes to complete and will create a `vercel-debug.txt` file in the current working directory, which you then can attach to your open support case with Vercel Support.
+Run the below mentioned command, depending on your operating system, from a terminal of your choice. This script will conduct various checks, and depending on different factors, it may take anywhere from 5 to 15 minutes to complete and will create a `vercel-debug.txt` file in the current working directory, which you then can attach to your open support case with Vercel Support.
 
 
 ## Commands to run:

--- a/vercel-debug.sh
+++ b/vercel-debug.sh
@@ -38,7 +38,7 @@ echo "├─────── Testing 76.76.21.21 "
 echo "" 
 ping -c 4 76.76.21.21
 echo "" 
-traceroute -w 1 -m 30 76.76.21.21
+traceroute -w 1 -m 30 -I 76.76.21.21
 echo "└───────────────────────────────────────"
 echo ""
 
@@ -50,7 +50,7 @@ do
   echo "" 
   ping -c 4 $i
   echo "" 
-  traceroute -w 1 -m 30 $i
+  traceroute -w 1 -m 30 -I $i
   echo "└───────────────────────────────────────"
   echo ""
 done


### PR DESCRIPTION
Use ICMP ECHO instead of UDP connections when using `traceroute` to speed things up.