### PR TITLE
Add -k flag to curl

### DIFF
--- a/vercel-debug.ps1
+++ b/vercel-debug.ps1
@@ -74,7 +74,7 @@ echo ""
 echo "+---------------------------------------"
 echo "+------- Output of ${domain}"
 echo "" 
-curl.exe -sv https://${domain} --stderr -
+curl.exe -svk https://${domain} --stderr -
 echo ""
 echo "+---------------------------------------"
 echo ""

--- a/vercel-debug.sh
+++ b/vercel-debug.sh
@@ -87,7 +87,7 @@ echo ""
 echo "┌───────────────────────────────────────"
 echo "├─────── Output of ${domain}"
 echo "" 
-curl -sv https://${domain} --stderr -
+curl -svk https://${domain} --stderr -
 echo ""
 echo "└───────────────────────────────────────"
 echo ""


### PR DESCRIPTION
Adds the -k flag to the curl output to continue to work with self-signed or invalid certs during an ISP AV/MITM block.