### PR TITLE
Domain validation

### DIFF
--- a/vercel-debug.ps1
+++ b/vercel-debug.ps1
@@ -2,9 +2,11 @@
 # Once completed, send the file to Vercel support
 
 # Ask for domain and don't accept no domain
+# Also, we need to ensure not to pass an URL (https://example.com/path) 
+# rather than only the domain name
 $domain = $null
-while (!$domain) {
-    $domain = Read-Host "Please enter your domain"
+while (!$domain || $domain -Match "`/") {
+    $domain = Read-Host "Domain to test (e.g. example.com): "
 }
 
 # Measure time 

--- a/vercel-debug.ps1
+++ b/vercel-debug.ps1
@@ -5,7 +5,7 @@
 # Also, we need to ensure not to pass an URL (https://example.com/path) 
 # rather than only the domain name
 $domain = $null
-while (!$domain || $domain -Match "`/") {
+while ((!$domain) -or ($domain -Match "`/")) {
     $domain = Read-Host "Domain to test (e.g. example.com): "
 }
 

--- a/vercel-debug.sh
+++ b/vercel-debug.sh
@@ -3,10 +3,12 @@
 # Once completed, send the file to Vercel support
 
 # Ask for domain and don't accept no domain
+# Also, we need to ensure not to pass an URL (https://example.com/path) 
+# rather than only the domain name
 domain=""
-while [[ -z "$domain" ]]
+while [[ -z "$domain" || "$domain" =~ '/' ]]
 do
-  echo "Domain to test: "
+  echo "Domain to test (e.g. example.com): "
   read domain </dev/tty
 done
 


### PR DESCRIPTION
- We need to ensure that only the domain is entered
- No paths allowed
- No protocol allowed

This is tested by the occurrence of a single `/`, which can either indicate a protocol (e.g. `https://`) or a path (e.g. `/foobar`).