### PR TITLE
Fix: show date as UTC

### DIFF
--- a/vercel-debug.ps1
+++ b/vercel-debug.ps1
@@ -18,7 +18,7 @@ echo "|"
 # Show affected domain
 echo "| Domain to test: ${domain} "
 # Capture time/date
-echo "| Timestamp: $(get-date)"
+echo "| Timestamp: $(get-date -AsUTC)"
 echo "+---------------------------------------"
 echo ""
 

--- a/vercel-debug.ps1
+++ b/vercel-debug.ps1
@@ -18,7 +18,7 @@ echo "|"
 # Show affected domain
 echo "| Domain to test: ${domain} "
 # Capture time/date
-echo "| Timestamp (UTC): $(get-date -AsUTC)"
+echo "| Timestamp (UTC): $((get-date).ToUniversalTime())"
 echo "| Timestamp (Local): $(get-date)"
 echo "+---------------------------------------"
 echo ""

--- a/vercel-debug.ps1
+++ b/vercel-debug.ps1
@@ -18,7 +18,8 @@ echo "|"
 # Show affected domain
 echo "| Domain to test: ${domain} "
 # Capture time/date
-echo "| Timestamp: $(get-date -AsUTC)"
+echo "| Timestamp (UTC): $(get-date -AsUTC)"
+echo "| Timestamp (Local): $(get-date)"
 echo "+---------------------------------------"
 echo ""
 

--- a/vercel-debug.sh
+++ b/vercel-debug.sh
@@ -21,7 +21,7 @@ echo "│"
 # Show affected domain
 echo "│ Domain to test: ${domain} "
 # Capture time/date
-echo "│ Timestamp: $(date)"
+echo "│ Timestamp: $(date -u)"
 echo "└───────────────────────────────────────"
 echo ""
 

--- a/vercel-debug.sh
+++ b/vercel-debug.sh
@@ -21,7 +21,8 @@ echo "│"
 # Show affected domain
 echo "│ Domain to test: ${domain} "
 # Capture time/date
-echo "│ Timestamp: $(date -u)"
+echo "│ Timestamp (UTC): $(date -u)"
+echo "| Timestamp (Local): $(date)"
 echo "└───────────────────────────────────────"
 echo ""
 


### PR DESCRIPTION
This shows the date of execution in UTC, allows to easier debug.

## How to test?
Run (Mac)
```
curl -s https://raw.githubusercontent.com/vercel-support/vercel-connect-debug/fix/use-utc-times/vercel-debug.sh | bash | tee vercel-debug.txt
```
or (for Windows)
```
Invoke-RestMethod -Uri https://raw.githubusercontent.com/vercel-support/vercel-connect-debug/fix/use-utc-times/vercel-debug.ps1 | Invoke-Expression | tee vercel-debug.txt
```

### Before changes:
```
// Mac
┌───────────────────────────────────────
├─────── STARTING
│
│ Domain to test: vercel.com 
│ Timestamp: Fri Jul  5 07:59:51 CEST 2024
└───────────────────────────────────────

// Windows
+------- STARTING
|
| Domain to test: vercel.com
| Timestamp: 07/05/2024 13:07:03
+---------------------------------------
```

### After changes:
```
// Mac
┌───────────────────────────────────────
├─────── STARTING
│
│ Domain to test: vercel.com 
│ Timestamp (UTC): Fri Jul  5 05:59:53 UTC 2024
│ Timestamp (Local): Fri Jul  5 07:59:53 CEST 2024
└───────────────────────────────────────

// Windows
+------- STARTING
|
| Domain to test: vercel.com
| Timestamp (UTC): 07/05/2024 11:07:05
| Timestamp (Local): 07/05/2024 13:07:05
+---------------------------------------
```