### PR TITLE
Run DNS/IP diagnostics even when IP range lookup fails

### DIFF
--- a/vercel-debug.ps1
+++ b/vercel-debug.ps1
@@ -9,19 +9,27 @@ while ((!$domain) -or ($domain -Match "`/")) {
     $domain = Read-Host "Domain to test (e.g. example.com): "
 }
 
+# Measure time
+$start = get-date
+
 # Lookup the DNS record to return the IP Ranges
 echo "+---------------------------------------"
 echo "+------- Fetching IP Addresses"
-echo "|" 
+echo "|"
 # Make curl request to the IP Range Lookup API
 $ip_addresses = curl.exe -s -X POST "https://ip-ranges.vercel.support" -d "${domain}"
 # Check if API call failed, returned empty, or returned special error responses
-# If any of these conditions are true, exit immediately without running tests
+# If any of these conditions are true, skip the per-IP reachability tests,
+# but still gather diagnostic info (reporter IP/ASN, DNS resolution, response body)
+# since a "Not on Vercel" result often indicates DNS-level hijacking/interception.
+$range_lookup_failed = $false
 if ($LASTEXITCODE -ne 0 -or [string]::IsNullOrEmpty($ip_addresses) -or $ip_addresses -eq "Not on Vercel" -or $ip_addresses -eq "DNS lookup failed" -or $ip_addresses -like "*Too Many Requests*") {
-    echo "| Range lookup failed - $(if ([string]::IsNullOrEmpty($ip_addresses)) { 'No response from API' } else { $ip_addresses })"
+    $range_lookup_failed = $true
+    $failure_reason = if ([string]::IsNullOrEmpty($ip_addresses)) { 'No response from API' } else { $ip_addresses }
+    echo "| Range lookup failed - $failure_reason"
+    echo "| Per-IP reachability tests will be skipped, but DNS/IP diagnostics will still run below."
     echo "+---------------------------------------"
     echo ""
-    return
 } else {
     echo "| ${domain} IP range: $ip_addresses"
     echo "+---------------------------------------"
@@ -30,12 +38,9 @@ if ($LASTEXITCODE -ne 0 -or [string]::IsNullOrEmpty($ip_addresses) -or $ip_addre
     $ip_range = ($ip_addresses -split ',').Trim()
 }
 
-# Measure time 
-$start = get-date
-
 echo "+---------------------------------------"
 echo "+------- STARTING"
-echo "|" 
+echo "|"
 # Show affected domain
 echo "| Domain to test: ${domain} "
 # Capture time/date
@@ -44,34 +49,37 @@ echo "| Timestamp (Local): $(get-date)"
 echo "+---------------------------------------"
 echo ""
 
-# Output the reporters IP address
+# Output the reporters IP address / ASN (useful for identifying the ISP
+# responsible for any interception)
 echo "+---------------------------------------"
 echo "+------- IP Information "
-echo "" 
+echo ""
 curl.exe -s https://ipinfo.io/
 echo ""
 echo "+---------------------------------------"
 echo ""
 
-# Test reachability to Vercel CNAME records
-ForEach ($i in $ip_range) {
-  echo "+---------------------------------------"
-  echo "+------- Testing $i "
-  echo "Checking headers via $i" 
-  # Get the headers of the site, bypassing DNS resolution and querying domain via IP directly
-  curl.exe -svko NUL https://$domain --connect-to ::$i --max-time 3 --stderr -
-  # Ping the IP
-  echo ""
-  echo "Checking ping to $i" 
-  ping -n 4 $i
-  # Skip traceroute if ping succeeds
-  if ($LASTEXITCODE -ne 0) {
-   echo ""
-   echo "Checking tracert to $i" 
-    tracert -w 1 -h 30 $i
+# Test reachability to Vercel CNAME records (only if the range lookup succeeded)
+if (-not $range_lookup_failed) {
+  ForEach ($i in $ip_range) {
+    echo "+---------------------------------------"
+    echo "+------- Testing $i "
+    echo "Checking headers via $i"
+    # Get the headers of the site, bypassing DNS resolution and querying domain via IP directly
+    curl.exe -svko NUL https://$domain --connect-to ::$i --max-time 3 --stderr -
+    # Ping the IP
+    echo ""
+    echo "Checking ping to $i"
+    ping -n 4 $i
+    # Skip traceroute if ping succeeds
+    if ($LASTEXITCODE -ne 0) {
+     echo ""
+     echo "Checking tracert to $i"
+      tracert -w 1 -h 30 $i
+    }
+    echo "+---------------------------------------"
+    echo ""
   }
-  echo "+---------------------------------------"
-  echo ""
 }
 
 # Resolve affected domain

--- a/vercel-debug.sh
+++ b/vercel-debug.sh
@@ -12,19 +12,27 @@ do
   read domain </dev/tty
 done
 
+# Measure time
+start=$(date +%s)
+
 # Lookup the DNS record to return the IP Ranges
 echo "┌───────────────────────────────────────"
 echo "├─────── Fetching IP Addresses"
-echo "│" 
+echo "│"
 # Make curl request to the IP Range Lookup API
 ip_addresses=$(curl -s -X POST "https://ip-ranges.vercel.support" -d "${domain}")
-# Check if API call failed, returned empty, or returned special error responses
-# If any of these conditions are true, exit immediately without running tests
-if [ $? -ne 0 ] || [ -z "$ip_addresses" ] || [ "$ip_addresses" = "Not on Vercel" ] || [ "$ip_addresses" = "DNS lookup failed" ] || [[ "$ip_addresses" == *"Too Many Requests"* ]]; then
+curl_exit=$?
+# Check if API call failed, returned empty, or returned special error responses.
+# If any of these are true, skip the per-IP reachability tests but still run
+# the DNS/IP diagnostics below, since a "Not on Vercel" result often indicates
+# DNS-level hijacking/interception by the local network or ISP.
+range_lookup_failed=0
+if [ $curl_exit -ne 0 ] || [ -z "$ip_addresses" ] || [ "$ip_addresses" = "Not on Vercel" ] || [ "$ip_addresses" = "DNS lookup failed" ] || [[ "$ip_addresses" == *"Too Many Requests"* ]]; then
+    range_lookup_failed=1
     echo "│ Range lookup failed - ${ip_addresses:-No response from API}"
+    echo "│ Per-IP reachability tests will be skipped, but DNS/IP diagnostics will still run below."
     echo "└───────────────────────────────────────"
     echo ""
-    exit 0
 else
     echo "│ ${domain} IP range: $ip_addresses"
     echo "└───────────────────────────────────────"
@@ -33,12 +41,9 @@ else
     ip_range=($(echo "$ip_addresses" | tr ',' ' '))
 fi
 
-# Measure time 
-start=$(date +%s)
-
 echo "┌───────────────────────────────────────"
 echo "├─────── STARTING"
-echo "│" 
+echo "│"
 # Show affected domain
 echo "│ Domain to test: ${domain} "
 # Capture time/date
@@ -47,37 +52,40 @@ echo "│ Timestamp (Local): $(date)"
 echo "└───────────────────────────────────────"
 echo ""
 
-# Output the reporters IP address
+# Output the reporters IP address / ASN (useful for identifying the ISP
+# responsible for any interception)
 echo "┌───────────────────────────────────────"
 echo "├─────── IP Information "
-echo "" 
+echo ""
 curl -s https://ipinfo.io/
 echo ""
 echo "└───────────────────────────────────────"
 echo ""
 
-# Test reachability to Vercel CNAME records
-for i in "${ip_range[@]}"
-do 
-  echo "┌───────────────────────────────────────"
-  echo "├─────── Testing $i "
-  echo "Checking headers via $i"  
-  # Get the headers of the site, bypassing DNS resolution and querying domain via IP directly
-  curl -svko /dev/null https://${domain} --connect-to ::${i} --max-time 3 --stderr -
-  # Ping the IP
-  echo ""
-  echo "Checking ping to $i" 
-  ping -c 4 $i
-  # Skip traceroute if ping succeeds
-  if [ $? -ne 0 ]
-  then
+# Test reachability to Vercel CNAME records (only if the range lookup succeeded)
+if [ $range_lookup_failed -eq 0 ]; then
+  for i in "${ip_range[@]}"
+  do
+    echo "┌───────────────────────────────────────"
+    echo "├─────── Testing $i "
+    echo "Checking headers via $i"
+    # Get the headers of the site, bypassing DNS resolution and querying domain via IP directly
+    curl -svko /dev/null https://${domain} --connect-to ::${i} --max-time 3 --stderr -
+    # Ping the IP
     echo ""
-    echo "Checking tracert to $i" 
-    traceroute -w 1 -m 30 -I $i
-  fi
-  echo "└───────────────────────────────────────"
-  echo ""
-done
+    echo "Checking ping to $i"
+    ping -c 4 $i
+    # Skip traceroute if ping succeeds
+    if [ $? -ne 0 ]
+    then
+      echo ""
+      echo "Checking tracert to $i"
+      traceroute -w 1 -m 30 -I $i
+    fi
+    echo "└───────────────────────────────────────"
+    echo ""
+  done
+fi
 
 # Resolve affected domain
 echo "┌───────────────────────────────────────"


### PR DESCRIPTION
## Summary
- When the IP range lookup returns `Not on Vercel`, `DNS lookup failed`, or an API error/empty response, the script previously exited immediately and reported nothing useful, even though these outcomes often indicate DNS-level hijacking by the local network or ISP.
- Replace the early `return`/`exit` with a `range_lookup_failed` flag that skips only the per-IP reachability loop (which needs a valid IP range), and let the rest of the script run so we still capture:
  - Reporter's public IP + ASN/org via `ipinfo.io`
  - Local DNS resolution (`nslookup -debug` / `dig`) to reveal any hijacked IPs
  - Public DNS resolution via `8.8.8.8` for comparison
  - Final `curl -svk https://$domain` to capture the intercepting cert/headers/body
- Move the `start` timestamp above the lookup so the `Time elapsed` line still computes correctly on the failure path.
- Applied to both `vercel-debug.ps1` and `vercel-debug.sh` to keep them in sync.

## Test plan
- `bash -n vercel-debug.sh` passes.
- Successful domain: output is unchanged aside from whitespace/comment tweaks.
- Failing domain (`Not on Vercel`): script prints the failure reason, skips the per-IP tests, and continues through IP info, DNS lookups, and the final `curl`.